### PR TITLE
修复 OneBlog Lite 在 CDN、Typecho 1.2 后台主题设置页、子目录/伪静态环境下的若干适配问题，并补充安全加固

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+Thumbs.db
+.DS_Store
+*.log
+*.tmp
+*.cache
+.idea/
+.vscode/
+node_modules/
+vendor/

--- a/api/link-status.php
+++ b/api/link-status.php
@@ -40,12 +40,84 @@ function oneblog_normalize_url($url) {
     return $url;
 }
 
+function oneblog_is_public_ip($ip) {
+    if (!filter_var($ip, FILTER_VALIDATE_IP)) return false;
+
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+        return (bool) filter_var(
+            $ip,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+        );
+    }
+
+    return (bool) filter_var(
+        $ip,
+        FILTER_VALIDATE_IP,
+        FILTER_FLAG_IPV6 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE
+    );
+}
+
+function oneblog_is_public_url($url) {
+    $parts = parse_url($url);
+    if (!$parts || empty($parts['scheme']) || empty($parts['host'])) return false;
+
+    $scheme = strtolower($parts['scheme']);
+    if (!in_array($scheme, ['http', 'https'], true)) return false;
+    if (!empty($parts['user']) || !empty($parts['pass'])) return false;
+
+    $port = isset($parts['port']) ? (int) $parts['port'] : ($scheme === 'https' ? 443 : 80);
+    if (!in_array($port, [80, 443], true)) return false;
+
+    $host = trim($parts['host'], '[]');
+    if (filter_var($host, FILTER_VALIDATE_IP)) {
+        return oneblog_is_public_ip($host);
+    }
+
+    $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+    if (!$records) return false;
+
+    foreach ($records as $record) {
+        $ip = $record['ip'] ?? ($record['ipv6'] ?? '');
+        if (!$ip || !oneblog_is_public_ip($ip)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function oneblog_resolve_public_ips($url) {
+    $parts = parse_url($url);
+    if (!$parts || empty($parts['host'])) return [];
+
+    $host = trim($parts['host'], '[]');
+    if (filter_var($host, FILTER_VALIDATE_IP)) {
+        return oneblog_is_public_ip($host) ? [$host] : [];
+    }
+
+    $records = @dns_get_record($host, DNS_A + DNS_AAAA);
+    if (!$records) return [];
+
+    $ips = [];
+    foreach ($records as $record) {
+        $ip = $record['ip'] ?? ($record['ipv6'] ?? '');
+        if (!$ip || !oneblog_is_public_ip($ip)) {
+            return [];
+        }
+        $ips[] = $ip;
+    }
+
+    return array_values(array_unique($ips));
+}
+
 function oneblog_read_urls() {
     $urls = $_POST['urls'] ?? ($_GET['urls'] ?? []);
     if (!empty($_REQUEST['url'])) $urls[] = $_REQUEST['url'];
     if (!is_array($urls)) $urls = [$urls];
 
     $urls = array_values(array_unique(array_filter(array_map('oneblog_normalize_url', $urls))));
+    $urls = array_values(array_filter($urls, 'oneblog_is_public_url'));
     return array_slice($urls, 0, 30);
 }
 
@@ -61,18 +133,35 @@ function oneblog_is_online_code($code) {
 }
 
 function oneblog_curl_options($url, $isHead) {
-    return [
+    $options = [
         CURLOPT_URL => $url,
         CURLOPT_TIMEOUT => 8,
         CURLOPT_CONNECTTIMEOUT => 5,
         CURLOPT_NOBODY => $isHead,
-        CURLOPT_FOLLOWLOCATION => true,
-        CURLOPT_MAXREDIRS => 3,
+        CURLOPT_FOLLOWLOCATION => false,
         CURLOPT_SSL_VERIFYPEER => false,
         CURLOPT_SSL_VERIFYHOST => false,
         CURLOPT_RETURNTRANSFER => true,
         CURLOPT_USERAGENT => 'Oneblog-LinkChecker',
     ];
+
+    if (defined('CURLOPT_RESOLVE')) {
+        $parts = parse_url($url);
+        $host = $parts['host'] ?? '';
+        $scheme = strtolower($parts['scheme'] ?? 'http');
+        $port = !empty($parts['port']) ? (int) $parts['port'] : ($scheme === 'https' ? 443 : 80);
+        if ($host) {
+            $resolve = [];
+            foreach (oneblog_resolve_public_ips($url) as $ip) {
+                $resolve[] = $host . ':' . $port . ':' . $ip;
+            }
+            if ($resolve) {
+                $options[CURLOPT_RESOLVE] = $resolve;
+            }
+        }
+    }
+
+    return $options;
 }
 
 function oneblog_check_once($url, $isHead) {
@@ -132,7 +221,17 @@ function oneblog_https_handshake($url) {
     if (!$host) return false;
 
     $port = !empty($parts['port']) ? (int) $parts['port'] : 443;
-    $fp = @stream_socket_client('ssl://' . $host . ':' . $port, $errno, $error, 6, STREAM_CLIENT_CONNECT);
+    $ips = oneblog_resolve_public_ips($url);
+    if (!$ips) return false;
+
+    $context = stream_context_create([
+        'ssl' => [
+            'peer_name' => $host,
+            'verify_peer' => false,
+            'verify_peer_name' => false,
+        ],
+    ]);
+    $fp = @stream_socket_client('ssl://' . $ips[0] . ':' . $port, $errno, $error, 6, STREAM_CLIENT_CONNECT, $context);
 
     if ($fp) {
         fclose($fp);

--- a/footer.php
+++ b/footer.php
@@ -88,7 +88,7 @@ document.addEventListener('DOMContentLoaded', function () {
 <script src="<?php $this->options->themeUrl('/static/js/comments.js?v=3.7.0'); ?>"></script>
 <?php endif;?>
 
-<script src="<?php $this->options->themeUrl('/static/js/main.js?v=3.7.0'); ?>"></script><!--主题js-->
+<script src="<?php $this->options->themeUrl('/static/js/main.js?v=3.7.1'); ?>"></script><!--主题js-->
 
 <!-- 版权信息 -->
 <div id="copyright-info" style="display: none;">
@@ -96,9 +96,12 @@ document.addEventListener('DOMContentLoaded', function () {
 </div>
 
 <script type="text/javascript">
-$(document).on('click', '#qq', function() {layer.msg('<?php $this->options->QQ();?>',{time:4000});});       
-$(document).on('click', '#wxmp', function() {layer.open({type: 1,title: false,closeBtn: 0,shadeClose: true,skin: 'layui-layer-nobg',area: ['auto'], content: '<img id= "mywxmp" style="width:20rem;height:20rem;display:block;" src="<?php $this->options->Weixin();?>">'});});
-$(document).on('click', '#tomail', function() {layer.msg('联系邮箱：<?php $this->options->Email();?>',{time:4000});});       
+$(document).on('click', '#qq', function() {layer.msg(<?php echo json_encode((string) $this->options->QQ, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>,{time:4000});});       
+$(document).on('click', '#wxmp', function() {
+    var wxmpUrl = <?php echo json_encode((string) $this->options->Weixin, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>;
+    layer.open({type: 1,title: false,closeBtn: 0,shadeClose: true,skin: 'layui-layer-nobg',area: ['auto'], content: $('<img>', {id: 'mywxmp', src: wxmpUrl}).css({width:'20rem',height:'20rem',display:'block'})});
+});
+$(document).on('click', '#tomail', function() {layer.msg('联系邮箱：' + <?php echo json_encode((string) $this->options->Email, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>,{time:4000});});       
 </script>
 <!--自定义JS代码-->
 <?php if (!empty($this->options->JS)): ?>

--- a/functions.php
+++ b/functions.php
@@ -491,6 +491,21 @@ function themeConfig($form) {
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['_ajax'])) {
         if (ob_get_length()) ob_clean();
         header('Content-Type:application/json; charset=utf-8');
+
+        $security = Helper::security();
+        try {
+            $security->protect();
+        } catch (Exception $e) {
+            echo json_encode(['success'=>false, 'message'=>'安全令牌无效，请刷新页面后重试'], JSON_UNESCAPED_UNICODE);
+            exit;
+        }
+
+        $user = Typecho_Widget::widget('Widget_User');
+        if (!$user->hasLogin()) {
+            echo json_encode(['success'=>false, 'message'=>'请先登录后台'], JSON_UNESCAPED_UNICODE);
+            exit;
+        }
+
         $theTheme = 'OneBlog';
         $db = Typecho_Db::get();
         $uploadDir = Helper::options()->uploadDir ?: 'usr/uploads';
@@ -501,13 +516,14 @@ function themeConfig($form) {
         }
         $backPath = $absUploadDir . '/BackupSetting_' . $theTheme . '.txt';
         $ret = ['success'=>false, 'message'=>'未知错误'];
-        if ($_POST['action'] === 'oneblog_theme_backup') {
+        $action = isset($_POST['action']) ? $_POST['action'] : '';
+        if ($action === 'oneblog_theme_backup') {
             $themeConfStr = $db->fetchRow($db->select()->from('table.options')->where('name = ?', 'theme:' . $theTheme))['value'];
             $ok = file_put_contents($backPath, $themeConfStr);
             $ret = $ok !== false
                 ? ['success'=>true, 'message'=>'备份成功']
                 : ['success'=>false, 'message'=>'备份失败，uploads 目录不可写'];
-        } elseif ($_POST['action'] === 'oneblog_theme_restore') {
+        } elseif ($action === 'oneblog_theme_restore') {
             if (file_exists($backPath)) {
                 $str = file_get_contents($backPath);
                 $updateThemeConQuery = $db->update('table.options')->rows(['value'=>$str])->where('name=?', 'theme:' . $theTheme);
@@ -541,6 +557,7 @@ function themeConfig($form) {
     <script src="https://cncdn.cc/layer/3.1.1/layer.js" type="text/javascript"></script>
     <script>
     window.oneblogFontConfigs = <?php echo json_encode(oneblogFonts(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES); ?>;
+    window.oneblogAdminToken = <?php echo json_encode(Helper::security()->getToken(Typecho_Request::getInstance()->getRequestUrl())); ?>;
     </script>
     <script src="<?php echo Helper::options()->themeUrl('static/js/admin.js'); ?>" type="text/javascript"></script>
     <div class="OneBlog"><h3>OneBlog 主题设置</h3></div>
@@ -875,7 +892,9 @@ function parseEmojis($content) {
     $emojiPath = Helper::options()->siteUrl.'usr/themes/OneBlog/static/img/emoji/';
     return preg_replace_callback('/\[emoji:([a-zA-Z0-9_]+)\]/', function($matches) use ($emojiPath) {
         $emojiName = $matches[1];
-        return '<img class="biaoqing" src="' . $emojiPath . $emojiName . '.svg" alt="' . $emojiName . '">';
+        $src = htmlspecialchars($emojiPath . $emojiName . '.svg', ENT_QUOTES, 'UTF-8');
+        $alt = htmlspecialchars($emojiName, ENT_QUOTES, 'UTF-8');
+        return '<img class="biaoqing" src="' . $src . '" alt="' . $alt . '">';
     }, $content);
 }
 
@@ -1108,6 +1127,7 @@ function themeInit($archive) {
 //评论点赞 cookie保证点赞数量准确
 function commentLikesNum($coid, &$record = NULL){
     $db = Typecho_Db::get();
+    $record = array();
     $callback = array(
         'likes' => 0,
         'recording' => false
@@ -1120,44 +1140,79 @@ function commentLikesNum($coid, &$record = NULL){
     if (empty($recording = Typecho_Cookie::get('__typecho_comment_likes_record'))) {
         Typecho_Cookie::set('__typecho_comment_likes_record', '[]');
     } else {
-        $callback['recording'] = is_array($record = json_decode($recording)) && in_array($coid, $record);
+        $record = json_decode($recording, true);
+        if (!is_array($record)) {
+            $record = array();
+        }
+        $callback['recording'] = in_array((int)$coid, array_map('intval', $record));
     }
     return $callback;
 }
 
 //评论点赞处理
 function commentLikes($archive){
-    $archive->response->setStatus(200); 
-    $_POST['coid'];
-    $_POST['behavior'];
-    $loginState = Typecho_Widget::widget('Widget_User')->hasLogin();
-    $res1 = commentLikesNum($_POST['coid'], $record);
+    $archive->response->setStatus(200);
+    header('Content-Type: application/json; charset=UTF-8');
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    header('Expires: 0');
+
+    if (!$archive->request->isPost()) {
+        $archive->response->throwJson(array(
+            "state" => "error",
+            "message" => "Method not allowed"
+        ));
+    }
+
+    $coid = isset($_POST['coid']) ? (int) $_POST['coid'] : 0;
+    $behavior = isset($_POST['behavior']) ? trim($_POST['behavior']) : '';
+    $res1 = commentLikesNum($coid, $record);
     $num = 0;
-    if(!empty($_POST['coid']) && !empty($_POST['behavior'])){
+    if(!empty($coid) && $behavior === 'dz'){
+        if ($res1['recording']) {
+            $archive->response->throwJson(array(
+                "state" => "error",
+                "message" => "你已经点过赞啦！",
+                "num" => $res1['likes']
+            ));
+        }
+
         $db = Typecho_Db::get();
         $prefix = $db->getPrefix();
-        $coid = (int)$_POST['coid'];
         if (!array_key_exists('likes', $db->fetchRow($db->select()->from('table.comments')))) {
         $db->query('ALTER TABLE `' . $prefix . 'comments` ADD `likes` INT(30) DEFAULT 0;');
         }
         $row = $db->fetchRow($db->select('likes')->from('table.comments')->where('coid = ?', $coid));
+        if (!$row) {
+            $archive->response->throwJson(array(
+                "state" => "error",
+                "message" => "评论不存在",
+                "num" => 0
+            ));
+        }
         $updateRows = $db->query($db->update('table.comments')->rows(array('likes' => (int) $row['likes'] + 1))->where('coid = ?', $coid));
         if($updateRows){
             $num = $row['likes'] + 1;
             $state =  "success";
-            array_push($record, $coid);
-            Typecho_Cookie::set('__typecho_comment_likes_record', json_encode($record));
+            $record[] = $coid;
+            Typecho_Cookie::set('__typecho_comment_likes_record', json_encode(array_values(array_unique($record))));
         }else{
             $num = $row['likes'];
             $state =  "error";
+            $message = "点赞失败，请稍后重试";
         }
     }else{
-        $state = 'Illegal request';
+        $state = 'error';
+        $message = 'Illegal request';
     }  
-    $archive->response->throwJson(array(
+    $result = array(
        "state" => $state,
        "num" => $num
-    ));    
+    );
+    if (!empty($message)) {
+        $result["message"] = $message;
+    }
+    $archive->response->throwJson($result);    
 }
 
 // 微语数据加载

--- a/functions.php
+++ b/functions.php
@@ -1136,10 +1136,13 @@ function commentLikesNum($coid, &$record = NULL){
         'likes' => 0,
         'recording' => false
     );
-    if (array_key_exists('likes', $data = $db->fetchRow($db->select()->from('table.comments')->where('coid = ?', $coid)))) {
-        $callback['likes'] = $data['likes'];
-    } else {
-        $db->query('ALTER TABLE `' . $db->getPrefix() . 'comments` ADD `likes` INT(10) NOT NULL DEFAULT 0;');
+    $data = $db->fetchRow($db->select()->from('table.comments')->where('coid = ?', $coid));
+    if (is_array($data)) {
+        if (array_key_exists('likes', $data)) {
+            $callback['likes'] = $data['likes'];
+        } else {
+            $db->query('ALTER TABLE `' . $db->getPrefix() . 'comments` ADD `likes` INT(10) NOT NULL DEFAULT 0;');
+        }
     }
     if (empty($recording = Typecho_Cookie::get('__typecho_comment_likes_record'))) {
         Typecho_Cookie::set('__typecho_comment_likes_record', '[]');
@@ -1170,9 +1173,9 @@ function commentLikes($archive){
 
     $coid = isset($_POST['coid']) ? (int) $_POST['coid'] : 0;
     $behavior = isset($_POST['behavior']) ? trim($_POST['behavior']) : '';
-    $res1 = commentLikesNum($coid, $record);
     $num = 0;
     if(!empty($coid) && $behavior === 'dz'){
+        $res1 = commentLikesNum($coid, $record);
         if ($res1['recording']) {
             $archive->response->throwJson(array(
                 "state" => "error",

--- a/functions.php
+++ b/functions.php
@@ -492,10 +492,14 @@ function themeConfig($form) {
         if (ob_get_length()) ob_clean();
         header('Content-Type:application/json; charset=utf-8');
 
+        $requestUrl = Typecho_Request::getInstance()->getRequestUrl();
         $security = Helper::security();
-        try {
-            $security->protect();
-        } catch (Exception $e) {
+        $token = isset($_POST['_']) ? (string) $_POST['_'] : '';
+        $validTokens = [$security->getToken($requestUrl)];
+        if (!empty($_SERVER['HTTP_REFERER'])) {
+            $validTokens[] = $security->getToken($_SERVER['HTTP_REFERER']);
+        }
+        if ($token === '' || !in_array($token, $validTokens, true)) {
             echo json_encode(['success'=>false, 'message'=>'安全令牌无效，请刷新页面后重试'], JSON_UNESCAPED_UNICODE);
             exit;
         }

--- a/memos.php
+++ b/memos.php
@@ -12,6 +12,12 @@ $memosImageEnabled = isset($export['activated']['MemosImage']);
 ob_start();
 $this->commentUrl();
 $oneblogCommentUrl = ob_get_clean();
+ob_start();
+$this->options->loginAction();
+$oneblogLoginAction = ob_get_clean();
+ob_start();
+Helper::options()->index('?commentLike=dz');
+$oneblogCommentLikeUrl = ob_get_clean();
 ?>
 <meta name="csrf-token" content="<?php echo htmlspecialchars(Helper::security()->getToken($this->request->getRequestUrl()), ENT_QUOTES, 'UTF-8'); ?>">
 <meta name="comment-url" content="<?php echo htmlspecialchars($oneblogCommentUrl, ENT_QUOTES, 'UTF-8'); ?>">
@@ -84,15 +90,23 @@ $oneblogCommentUrl = ob_get_clean();
 </div>
 
 <script>
-    var loginAction = <?php echo json_encode($this->options->loginAction(), JSON_UNESCAPED_SLASHES); ?>;
-    var commentLikeUrl = <?php echo json_encode(Helper::options()->index . '?commentLike=dz', JSON_UNESCAPED_SLASHES); ?>;
+    var loginAction = <?php echo json_encode($oneblogLoginAction, JSON_UNESCAPED_SLASHES); ?>;
+    var commentLikeUrl = <?php echo json_encode($oneblogCommentLikeUrl, JSON_UNESCAPED_SLASHES); ?>;
     <?php if ($memosImageEnabled) : ?>
     <?php $plugin = $this->options->plugin('MemosImage'); ?>
+    <?php
+    ob_start();
+    Helper::options()->index('/action/memos-upload');
+    $oneblogMemosUploadUrl = ob_get_clean();
+    ob_start();
+    Helper::options()->index('/action/memos-sign');
+    $oneblogMemosSignUrl = ob_get_clean();
+    ?>
     window.memosConfig = Object.assign({}, window.memosConfig || {}, {
         enabled: true,
         memosUseCos: <?php echo json_encode(($plugin->uploadMode ?: 'local') === 'cos'); ?>,
-        memosUploadUrl: <?php echo json_encode(Helper::options()->index . '/action/memos-upload', JSON_UNESCAPED_SLASHES); ?>,
-        memosSignUrl: <?php echo json_encode(Helper::options()->index . '/action/memos-sign', JSON_UNESCAPED_SLASHES); ?>
+        memosUploadUrl: <?php echo json_encode($oneblogMemosUploadUrl, JSON_UNESCAPED_SLASHES); ?>,
+        memosSignUrl: <?php echo json_encode($oneblogMemosSignUrl, JSON_UNESCAPED_SLASHES); ?>
     });
     <?php endif; ?>
 </script>

--- a/memos.php
+++ b/memos.php
@@ -9,16 +9,19 @@ if (!defined('__TYPECHO_ROOT_DIR__')) exit;
 $this->need('header.php');
 $export = Typecho_Plugin::export();
 $memosImageEnabled = isset($export['activated']['MemosImage']);
+ob_start();
+$this->commentUrl();
+$oneblogCommentUrl = ob_get_clean();
 ?>
-<meta name="csrf-token" content="<?php echo Helper::security()->getToken($this->request->getRequestUrl()); ?>">
-<meta name="comment-url" content="<?php $this->commentUrl(); ?>">
+<meta name="csrf-token" content="<?php echo htmlspecialchars(Helper::security()->getToken($this->request->getRequestUrl()), ENT_QUOTES, 'UTF-8'); ?>">
+<meta name="comment-url" content="<?php echo htmlspecialchars($oneblogCommentUrl, ENT_QUOTES, 'UTF-8'); ?>">
 
 <div class="main">
 <?php $this->need('module/head2.php'); ?>
 
 <div class="page_thumb blur">
     <div class="post_bg lazy-load"
-         data-src="<?php echo $this->fields->thumb ? $this->fields->thumb : Helper::options()->themeUrl . '/static/img/memos.jpg'; ?>">
+         data-src="<?php echo htmlspecialchars($this->fields->thumb ? $this->fields->thumb : Helper::options()->themeUrl . '/static/img/memos.jpg', ENT_QUOTES, 'UTF-8'); ?>">
     </div>
 
     <div class="pc">
@@ -31,7 +34,7 @@ $memosImageEnabled = isset($export['activated']['MemosImage']);
                 </h1>
             <?php else : ?>
                 <a class="logo" href="<?php $this->options->siteUrl(); ?>">
-                    <img src="<?php echo $this->options->logoWhite ?: Helper::options()->themeUrl . '/static/img/logoWhite.svg'; ?>">
+                    <img src="<?php echo htmlspecialchars($this->options->logoWhite ?: Helper::options()->themeUrl . '/static/img/logoWhite.svg', ENT_QUOTES, 'UTF-8'); ?>">
                 </a>
             <?php endif; ?>
         </div>
@@ -81,15 +84,15 @@ $memosImageEnabled = isset($export['activated']['MemosImage']);
 </div>
 
 <script>
-    var loginAction = "<?php echo $this->options->loginAction(); ?>";
-    var commentLikeUrl = "<?php Helper::options()->index('?commentLike=dz'); ?>";
+    var loginAction = <?php echo json_encode($this->options->loginAction(), JSON_UNESCAPED_SLASHES); ?>;
+    var commentLikeUrl = <?php echo json_encode(Helper::options()->index . '?commentLike=dz', JSON_UNESCAPED_SLASHES); ?>;
     <?php if ($memosImageEnabled) : ?>
     <?php $plugin = $this->options->plugin('MemosImage'); ?>
     window.memosConfig = Object.assign({}, window.memosConfig || {}, {
         enabled: true,
-        memosUseCos: "<?php echo $plugin->uploadMode ?: 'local'; ?>" === 'cos',
-        memosUploadUrl: "<?php Helper::options()->index('/action/memos-upload'); ?>",
-        memosSignUrl: "<?php Helper::options()->index('/action/memos-sign'); ?>"
+        memosUseCos: <?php echo json_encode(($plugin->uploadMode ?: 'local') === 'cos'); ?>,
+        memosUploadUrl: <?php echo json_encode(Helper::options()->index . '/action/memos-upload', JSON_UNESCAPED_SLASHES); ?>,
+        memosSignUrl: <?php echo json_encode(Helper::options()->index . '/action/memos-sign', JSON_UNESCAPED_SLASHES); ?>
     });
     <?php endif; ?>
 </script>

--- a/static/js/admin.js
+++ b/static/js/admin.js
@@ -278,7 +278,7 @@ jQuery(function($){
             if(confirm('确定要备份当前主题配置吗？')) doBackup();
         }
         function doBackup(){
-            $.post(location.href, {action:'oneblog_theme_backup', _ajax:1}, function(res){
+            $.post(location.href, {action:'oneblog_theme_backup', _ajax:1, _: window.oneblogAdminToken || ''}, function(res){
                 if(res && res.success){
                     showResult(res.message, 1, true);
                 }else{
@@ -300,7 +300,7 @@ jQuery(function($){
             if(confirm('确定要恢复主题配置吗？恢复操作不可逆，请谨慎！')) doRestore();
         }
         function doRestore(){
-            $.post(location.href, {action:'oneblog_theme_restore', _ajax:1}, function(res){
+            $.post(location.href, {action:'oneblog_theme_restore', _ajax:1, _: window.oneblogAdminToken || ''}, function(res){
                 if(res && res.success){
                     showResult(res.message, 1, true);
                 }else{

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -956,6 +956,10 @@ $(document).ready(function() {
         $.ajax({
             url: commentLikeUrl,
             type: "POST",
+            cache: false,
+            headers: {
+                "X-Requested-With": "XMLHttpRequest"
+            },
             data: {
                 coid: coid,
                 behavior: 'dz'
@@ -973,7 +977,10 @@ $(document).ready(function() {
                     }
                 }
             },
-            error: function(err) {
+            error: function(xhr) {
+                if (window.console && console.warn) {
+                    console.warn("Comment like request failed", xhr.status, xhr.responseText);
+                }
                 alert("点赞失败，请稍后重试");
             }
         });


### PR DESCRIPTION
## 变更说明

本次 PR 修复 OneBlog Lite 在 CDN、Typecho 1.2 后台主题设置页、子目录/伪静态环境下的若干适配问题，并补充安全加固。

资源引用保持现有 3.7.0 体系不变，仅更新本地 `main.js` 查询版本以避免 CDN 继续命中旧脚本缓存。

## 修复内容

### 1. 修复 CDN 环境下微语点赞失败

原点赞接口使用 `?commentLike=dz` 动态入口，在部分 CDN 配置下可能被缓存、拦截或返回非 JSON 内容，导致前端提示“点赞失败”。

本次调整：

- 点赞接口只接受 `POST`
- 点赞接口返回 JSON 前增加禁止缓存响应头
- 前端 AJAX 增加 `X-Requested-With`
- 前端禁用请求缓存，并在失败时输出调试信息
- 更新 `main.js` 查询版本，避免 CDN 继续使用旧脚本
- 修复首次点赞时点赞记录 cookie 为空导致后端异常的问题
- 修复空 `coid`、非法 `coid`、不存在评论 ID 等边界请求可能触发后端异常的问题

### 2. 修复 Typecho URL 输出适配

运行版 Typecho 中 `Options::index()`、`loginAction()` 为直接输出型方法，不能当返回值拼接使用。

本次调整：

- 微语页登录地址改为捕获 Typecho 输出结果
- 点赞接口地址改为由 Typecho 生成后再写入 JS
- MemosImage 上传/签名接口地址改为由 Typecho 生成，兼容子目录、伪静态、`index.php` 路由等部署方式

### 3. 修复后台主题配置备份/恢复 AJAX 校验

Typecho 1.2 的 `Security::protect()` 校验失败会直接 `goBack()`，用于 AJAX 时可能返回 HTML/跳转页面而非 JSON。

本次调整：

- 后台备份/恢复 AJAX 显式携带安全 token
- 后端显式校验 token 和登录态
- 校验失败稳定返回 JSON，避免前端误判为“备份失败/恢复失败”且难以定位

### 4. 加固外链检测接口 SSRF 风险

`api/link-status.php` 会根据用户传入 URL 由服务器发起请求，本次限制其可访问目标：

- 仅允许 `http` / `https`
- 仅允许公网 IP / 公网 DNS 解析结果
- 仅允许 80 / 443 端口
- 禁止自动跟随跳转
- 使用 `CURLOPT_RESOLVE` 固定已验证解析结果，降低 DNS rebinding 风险

### 5. 补充输出转义

对部分直接输出到 HTML / JS 的主题配置值进行转义或 `json_encode` 处理，降低配置值导致前端注入的风险。

涉及位置包括：

- 微语页接口地址、登录地址、上传地址等 JS 变量
- 页脚 QQ / 微信 / 邮箱弹窗内容
- 表情短代码生成的图片属性

## 验证情况

已结合一套运行过的完整 Typecho 环境复查：

- Typecho `Options::index()` / `loginAction()` 输出行为
- Typecho `Security::protect()` AJAX 下的跳转行为
- 后台主题设置页 `themeConfig()` 调用链路
- 前台评论与 `throwJson()` 响应行为